### PR TITLE
feat: add combine page and absolute baseURL path

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,6 +17,6 @@ export default defineNuxtConfig({
         viewer: true,
     },
     app: {
-        baseURL: "./",
+        baseURL: "/somepath",
     }
 })

--- a/pages/combine/index.vue
+++ b/pages/combine/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Hello from combine
+  </div>
+</template>


### PR DESCRIPTION
By default, nuxt expects the static page to be deployed to the root domain, e.g., https://mydomain.com/.

If you will deploy to a path, e.g., https://mydomain.com/somepath, you will need to modify the `app.baseURL` in `nuxt.config`. (see the commit I made)

For the pages, here is how it works: https://v3.nuxtjs.org/guide/directory-structure/pages/

Assuming you are deploying to path `/somepath`, if you want to edit page https://mydomain.com/somepath/combine, you will need to edit `pages/combine/index.vue`.
If you want to edit https://mydomain.com/somepath/about/company, you will need to edit `pages/about/company/index.vue`. Etc.